### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_gandi.py
+++ b/tests/test_octodns_provider_gandi.py
@@ -160,7 +160,7 @@ class TestGandiProvider(TestCase):
         del provider._zone_records[zone.name]
 
     def test_apply(self):
-        provider = GandiProvider('test_id', 'token')
+        provider = GandiProvider('test_id', 'token', strict_supports=False)
 
         # Zone does not exists but can be created.
         with requests_mock() as mock:


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957