### PR TITLE
v0.0.2 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.2 - 2023-10-19 - Cya ApiKey, Welcome PAT
+
+- Use Personal Access Token (PAT) authentication instead of ApiKey (deprecated by Gandhi)
+
 ## v0.0.1 - 2022-01-09 - Moving
 
 #### Nothworthy Changes

--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ octodns-gandi==0.0.1
 providers:
   gandi:
     class: octodns_gandi.GandiProvider
-    # Your API key (required)
+    # Your personal access token (required)
     token: env/GANDI_TOKEN
 ```
+
+The minimum permissions your Personal Access Token must have are
+
+* See and renew domain names
+* Manage domain name technical configurations
 
 ### Support Information
 

--- a/octodns_gandi/__init__.py
+++ b/octodns_gandi/__init__.py
@@ -12,7 +12,7 @@ from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class GandiClientException(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2023-10-19 - Cya ApiKey, Welcome PAT

- Use Personal Access Token (PAT) authentication instead of ApiKey (deprecated by Gandhi)

Thanks @Support-Green-IT-Solutions