### PR TITLE
Version 1.1.0 changelog update and verion bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.?.0 - 2025-??-?? - Turn the page
+## v1.1.0 - 2025-07-01 - Turn the page
 
 * Add support for paginating records and new `per_page` provider option to
   configure the page size, default is 500

--- a/octodns_gandi/__init__.py
+++ b/octodns_gandi/__init__.py
@@ -13,7 +13,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.1.0'
 
 
 class GandiClientException(ProviderException):


### PR DESCRIPTION
## v1.1.0 - 2025-07-01 - Turn the page

* Add support for paginating records and new `per_page` provider option to
  configure the page size, default is 500