### PR TITLE
Version 1.2.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/15c330383cf3414d9291404127f15982.md
+++ b/.changelog/15c330383cf3414d9291404127f15982.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/313cfd3007be469985c82c1e0c363a98.md
+++ b/.changelog/313cfd3007be469985c82c1e0c363a98.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/5c821a6096f54bc5a34eeb474605a9d9.md
+++ b/.changelog/5c821a6096f54bc5a34eeb474605a9d9.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/63274ab982974d0ea3a166b03dc8f4f5.md
+++ b/.changelog/63274ab982974d0ea3a166b03dc8f4f5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/677a17aabdbc44b5afbaff321357e26c.md
+++ b/.changelog/677a17aabdbc44b5afbaff321357e26c.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/777a950bc6b34b0399a8d34dc8b41599.md
+++ b/.changelog/777a950bc6b34b0399a8d34dc8b41599.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add list_zones support for dynamic configuration

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/92fbced775304bb88c7f8dee8ebd7f4e.md
+++ b/.changelog/92fbced775304bb88c7f8dee8ebd7f4e.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/98bf9ffd817e45d9b2a1ea6cdb1da50a.md
+++ b/.changelog/98bf9ffd817e45d9b2a1ea6cdb1da50a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/ffcbaff9d0794d6c8ec1dab4e0e21768.md
+++ b/.changelog/ffcbaff9d0794d6c8ec1dab4e0e21768.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0 - 2026-04-03
+
+Minor:
+* Add list_zones support for dynamic configuration - [#57](https://github.com/octodns/octodns-gandi/pull/57)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#54](https://github.com/octodns/octodns-gandi/pull/54)
+
 ## v1.1.0 - 2025-07-01 - Turn the page
 
 * Add support for paginating records and new `per_page` provider option to

--- a/octodns_gandi/__init__.py
+++ b/octodns_gandi/__init__.py
@@ -13,7 +13,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.1.0'
+__version__ = __VERSION__ = '1.2.0'
 
 
 class GandiClientException(ProviderException):


### PR DESCRIPTION
## 1.2.0 - 2026-04-03

Minor:
* Add list_zones support for dynamic configuration - [#57](https://github.com/octodns/octodns-gandi/pull/57)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#54](https://github.com/octodns/octodns-gandi/pull/54)

